### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .cache/
 public
 src/gatsby-types.d.ts
+.DS_Store


### PR DESCRIPTION
Adds `.DS_Store` to `.gitignore`, which is a Mac OS specific metadata file and should be ignored.