### PR TITLE
Update pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint:fix && npm run format && git add -A .
+npm run lint:fix
+npm run format
+
+git diff --staged --name-only | xargs git add


### PR DESCRIPTION
Addresses #38 by using `git diff --staged --name-only` to only add staged files to the commit.

Caveat here is that `npm run lint:fix` and `npm run format` will still run for all files in the working directory. Tried fixing it by passing the staged files in `git diff --staged --name-only` to the linters/formatters, but unfortunately passing specific files with `xargs` will throw an error to file types that aren't recognized like `No parser could be inferred for file: .husky/pre-commit`. Also tried stashing untracked/unstaged files with `git stash push -k -u` before linting and `git stash pop` after but that seemed very error prone.